### PR TITLE
Fixed PYTHON_TEMPLATE Path Join

### DIFF
--- a/scripts/sky.newScript.py
+++ b/scripts/sky.newScript.py
@@ -2,8 +2,8 @@
 
 import re, os, shutil
 
-KIT_PATH  = lx.eval("query platformservice alias ? {kit_mecco_sky_py:}")
-PYTHON_TEMPLATE = os.join(KIT_PATH,'assets','snippets','blank.py')
+KIT_PATH = lx.eval("query platformservice alias ? {kit_mecco_sky_py:}")
+PYTHON_TEMPLATE = os.path.join(KIT_PATH, 'assets', 'snippets', 'blank.py')
 
 lx.out('PYTHON_TEMPLATE: ' + PYTHON_TEMPLATE)
 


### PR DESCRIPTION
There is no such thing as os.join(). You probably meant os.path.join(), which gives me the result I expect. A fully concatenated path. :)

Signed-off-by: Alexander Kucera a.kucera@babylondreams.de
